### PR TITLE
Add members and teams modules

### DIFF
--- a/lib/ex_clubhouse/api.ex
+++ b/lib/ex_clubhouse/api.ex
@@ -2,6 +2,8 @@ defmodule ExClubhouse.API do
   alias ExClubhouse.API.V2.{
     Projects,
     Stories,
+    Members,
+    Teams
   }
 
   @doc """
@@ -18,4 +20,24 @@ defmodule ExClubhouse.API do
   Fetch all stories in a project.
   """
   defdelegate stories(project_id), to: Stories
+
+  @doc """
+  Fetch all of the teams in an organization.
+  """
+  defdelegate teams(), to: Teams
+
+  @doc """
+  Fetch a team by id
+  """
+  defdelegate team(id), to: Teams
+
+  @doc """
+  Fetch all of the members in an organization.
+  """
+  defdelegate members(), to: Members
+
+  @doc """
+  Fetch a member by id
+  """
+  defdelegate member(id), to: Members
 end

--- a/lib/ex_clubhouse/api/v2/members.ex
+++ b/lib/ex_clubhouse/api/v2/members.ex
@@ -1,0 +1,25 @@
+defmodule ExClubhouse.API.V2.Members do
+  alias ExClubhouse.API.V2.Client
+  alias ExClubhouse.Mapper
+  alias ExClubhouse.Schemas.Member
+
+  def members do
+    case Client.get!("/member") do
+      %{status_code: 200, body: body} ->
+        {:ok, Mapper.map(body, Member)}
+
+      res ->
+        {:error, res}
+    end
+  end
+
+  def member(id) do
+    case Client.get!("/members/#{id}") do
+      %{status_code: 200, body: body} ->
+        {:ok, Mapper.map(body, Member)}
+
+      res ->
+        {:error, res}
+    end
+  end
+end

--- a/lib/ex_clubhouse/api/v2/teams.ex
+++ b/lib/ex_clubhouse/api/v2/teams.ex
@@ -1,0 +1,25 @@
+defmodule ExClubhouse.API.V2.Teams do
+  alias ExClubhouse.API.V2.Client
+  alias ExClubhouse.Mapper
+  alias ExClubhouse.Schemas.Team
+
+  def teams do
+    case Client.get!("/teams") do
+      %{status_code: 200, body: body} ->
+        {:ok, Mapper.map(body, Team)}
+
+      res ->
+        {:error, res}
+    end
+  end
+
+  def team(id) do
+    case Client.get!("/teams/#{id}") do
+      %{status_code: 200, body: body} ->
+        {:ok, Mapper.map(body, Team)}
+
+      res ->
+        {:error, res}
+    end
+  end
+end

--- a/lib/ex_clubhouse/schemas/member.ex
+++ b/lib/ex_clubhouse/schemas/member.ex
@@ -1,0 +1,12 @@
+defmodule ExClubhouse.Schemas.Member do
+  use ExClubhouse.Schema
+
+  embedded_schema do
+    field :created_at, :utc_datetime
+    field :disabled, :boolean
+    field :entity_type, :string
+    field :profile, :map
+    field :role, :string
+    field :updated_at, :utc_datetime
+  end
+end

--- a/lib/ex_clubhouse/schemas/team.ex
+++ b/lib/ex_clubhouse/schemas/team.ex
@@ -1,0 +1,14 @@
+defmodule ExClubhouse.Schemas.Team do
+  use ExClubhouse.Schema
+
+  embedded_schema do
+    field :created_at, :utc_datetime
+    field :description, :string
+    field :entity_type, :string
+    field :name, :string
+    field :position, :integer
+    field :project_ids, {:array, :integer}
+    field :updated_at, :utc_datetime
+    field :workflow, :map
+  end
+end


### PR DESCRIPTION
search_by_name works only if you get the name right. Is this where you would use that arrow that points the other way?